### PR TITLE
Fix urllib3 CVEs by upgrading to Python 3.10 in twctf-2019/easy_crack_me

### DIFF
--- a/twctf-2019/easy_crack_me/Pipfile
+++ b/twctf-2019/easy_crack_me/Pipfile
@@ -10,4 +10,4 @@ pwntools = "*"
 [dev-packages]
 
 [requires]
-python_version = "3.9"
+python_version = "3.10"

--- a/twctf-2019/easy_crack_me/Pipfile.lock
+++ b/twctf-2019/easy_crack_me/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "6f98bd8631bf4a5c597dc37489ef24a453996bc798f2a2701176966631404c31"
+            "sha256": "ad4ec314bfeadcffd6018efe61414f34865b704c2e7bccad482ee349fe17b55a"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.9"
+            "python_version": "3.10"
         },
         "sources": [
             {
@@ -626,7 +626,7 @@
                 "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.9'",
+            "markers": "python_version >= '3.10'",
             "version": "==2.7.0"
         },
         "z3-solver": {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Upgrades `python_version` from `3.9` to `3.10` in `Pipfile` and `Pipfile.lock`
- Fixes two high-severity urllib3 CVEs (GHSA-qccp-gfcp-xxvc, GHSA-mf9v-mfxr-j63j) by making the lock file consistent with the already-pinned urllib3 2.7.0
- Corrects the `_meta.hash`, `_meta.requires.python_version`, and urllib3 `markers` fields in `Pipfile.lock`

## Root cause

urllib3 2.7.0 (which fixes both CVEs) requires **Python >= 3.10**, but the Pipfile declared `python_version = "3.9"`. This is why dependabot alert #46 could not be resolved automatically — pipenv correctly refused to pin an incompatible version. The manual patch in `bada372` pinned 2.7.0 in the lock file without updating the Python requirement, leaving the lock file internally inconsistent.

## Changes

| File | Change |
|------|--------|
| `Pipfile` | `python_version = "3.9"` → `"3.10"` |
| `Pipfile.lock` `_meta.hash.sha256` | recomputed for new Pipfile |
| `Pipfile.lock` `_meta.requires.python_version` | `"3.9"` → `"3.10"` |
| `Pipfile.lock` urllib3 `markers` | `python_version >= '3.9'` → `python_version >= '3.10'` |

## Test plan

- [ ] Verify `pipenv install` succeeds on Python 3.10
- [ ] Confirm dependabot alert #46 closes after merge

https://claude.ai/code/session_019qycv8HUprVRmL4nLfvSe4
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_019qycv8HUprVRmL4nLfvSe4)_